### PR TITLE
Add test case for using custom events with the same name as Map function

### DIFF
--- a/mmr-testing/mediasource-eventlisteners.html
+++ b/mmr-testing/mediasource-eventlisteners.html
@@ -2,7 +2,7 @@
 <!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
-        <title>Simple MediaSource playback test case.</title>
+        <title>EventListener and dispatchEvent test case.</title>
         <meta name="timeout" content="long">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>

--- a/mmr-testing/mediasource-eventlisteners.html
+++ b/mmr-testing/mediasource-eventlisteners.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
+<html>
+    <head>
+        <title>Simple MediaSource playback test case.</title>
+        <meta name="timeout" content="long">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>                        
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              // use event name 'has' to check for bug 40470560 where
+              // we would mistakently use javascript properties instead of map
+              let eventName = 'has';
+              
+              test.expectEvent(mediaElement, eventName, 'mediaElement');
+              mediaSource.addEventListener(eventName, test.step_func_done());
+              
+              let mediaElementEvent = new CustomEvent('has', {});
+              test.waitForExpectedEvents(function()
+              {
+                  let mediaSourceEvent = new CustomEvent('has', {});
+                  mediaSource.dispatchEvent(mediaSourceEvent);
+              });
+              mediaElement.dispatchEvent(mediaElementEvent);
+          }, "Test dispatchEvent for custom event type 'has'");
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This exposes an issue for bug 40470560.
It also exposes an issue for previous change PR#7435721 where we aren't respecting dispatchEvent with custom events